### PR TITLE
Fix schemas to only require caseExact if type is a string

### DIFF
--- a/src/main/resources/schema/Schema.schema.json
+++ b/src/main/resources/schema/Schema.schema.json
@@ -121,10 +121,41 @@
                 "multiValued",
                 "description",
                 "required",
-                "caseExact",
                 "mutability",
                 "returned"
-            ]
+            ],
+            "dependencies": {
+                "type": {
+                    "oneOf": [
+                        {
+                            "properties": {
+                                "type": {
+                                    "enum": ["string"]
+                                },
+                                "caseExact": {
+                                    "type": "boolean"
+                                }
+                            },
+                            "required": ["caseExact"]
+                        },
+                        {
+                            "properties": {
+                                "type": {
+                                    "enum": [
+                                        "boolean",
+                                        "decimal",
+                                        "integer",
+                                        "dateTime",
+                                        "reference",
+                                        "complex",
+                                        "binary"
+                                    ]
+                                }
+                            }
+                        }
+                    ]
+                }
+            }
         }
     }
 }

--- a/src/main/resources/schema/Schemas.schema.json
+++ b/src/main/resources/schema/Schemas.schema.json
@@ -152,10 +152,41 @@
                 "multiValued",
                 "description",
                 "required",
-                "caseExact",
                 "mutability",
                 "returned"
-            ]
+            ],
+            "dependencies": {
+                "type": {
+                    "oneOf": [
+                        {
+                            "properties": {
+                                "type": {
+                                    "enum": ["string"]
+                                },
+                                "caseExact": {
+                                    "type": "boolean"
+                                }
+                            },
+                            "required": ["caseExact"]
+                        },
+                        {
+                            "properties": {
+                                "type": {
+                                    "enum": [
+                                        "boolean",
+                                        "decimal",
+                                        "integer",
+                                        "dateTime",
+                                        "reference",
+                                        "complex",
+                                        "binary"
+                                    ]
+                                }
+                            }
+                        }
+                    ]
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
Currently, `caseExact` is required to be specified on all attributes, however RFC 7644, article 3.4.2.2 only mentions checking this field on String types:

```
When comparing attributes of type String, the case sensitivity for
   String type attributes SHALL be determined by the attribute's
   "caseExact" characteristic (see [Section 2.2 of [RFC7643]](https://datatracker.ietf.org/doc/html/rfc7643#section-2.2)).
 ```
 
This value makes no sense on other types, as a boolean or complex object does not have 'case', therefore it's often not defined.

This PR enables checking it on String types, while ignoring the field on other types.