### PR TITLE
Do not check Content-Type upon 204 code

### DIFF
--- a/src/main/java/dev/suvera/opensource/scim2/compliance/biz/ScimResponseValidator.java
+++ b/src/main/java/dev/suvera/opensource/scim2/compliance/biz/ScimResponseValidator.java
@@ -80,6 +80,11 @@ public class ScimResponseValidator {
             );
         }
 
+        // No reason to check Content-Type on 204
+        if (statusCode == 204) {
+            return;
+        }
+
         List<String> contentTypes = headers.get("Content-Type");
         boolean found = false;
         for (String expected : ScimConstants.CONTENT_TYPES) {


### PR DESCRIPTION
204 No Content does not return any content and thus, according to the HTTP specification, does not require a Content-Type. None of the examples in RFC 7644 include a Content-Type for 204 responses, even if they do for 200 responses.

Therefore, we should not check it on 204 responses, the header should be ignored.